### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for instructions on building, r
 
 This library is released under the terms of the Apache Softare License version 2.0.
 See [the license file](./LICENSE) for more details.
+
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.