### PR TITLE
Update for SplunkOtel 0.11.0 & Podspec

### DIFF
--- a/SplunkOtelCrashReporting.podspec
+++ b/SplunkOtelCrashReporting.podspec
@@ -1,0 +1,38 @@
+#
+# NOTE: Be sure to run
+#
+# `pod lib lint SplunkOtelCrashReporting.podspec`
+#
+#  to ensure this is a valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'SplunkOtelCrashReporting'  
+  s.version          = '0.6.0'  
+  s.summary          = 'Splunk OpenTelemetry Crash Reporting pod for iOS' 
+  s.description      = <<-DESC
+The Splunk RUM agent for iOS provides a Swift package that captures:
+HTTP requests, using URLSession instrumentation
+Application startup information
+UI activity - screen name (typically ViewController name), actions, and PresentationTransitions
+Crashes/unhandled exceptions using SplunkRumCrashReporting
+🚧 This project is currently in BETA. It is officially supported by Splunk. However, breaking changes MAY be introduced.
+DESC
+
+  s.swift_version    = '5.1'
+  s.cocoapods_version = '>= 1.10'
+
+  s.homepage         = 'https://github.com/signalfx/splunk-otel-ios.git'
+  s.license          = { :type => "Apache", :file => 'LICENSE' }
+  s.author           = { 'Splunk' => 'www.splunk.com' }
+  s.source           = { :git => 'https://github.com/signalfx/splunk-otel-ios-crashreporting.git', :tag => s.version.to_s }
+# Make sure the deployment target matches with Package.swift
+  s.ios.deployment_target = '11.0'
+  s.source_files = 'SplunkRumCrashReporting/SplunkRumCrashReporting/**/*.swift'
+  s.static_framework = true
+  s.dependency 'PLCrashReporter', '~> 1.11.1'
+  s.dependency 'SplunkOtel', '~> 0.11.0'
+end

--- a/SplunkRumCrashReporting/SplunkRumCrashReporting.xcodeproj/project.pbxproj
+++ b/SplunkRumCrashReporting/SplunkRumCrashReporting.xcodeproj/project.pbxproj
@@ -522,7 +522,7 @@
 			repositoryURL = "https://github.com/microsoft/plcrashreporter";
 			requirement = {
 				kind = exactVersion;
-				version = 1.9.0;
+				version = 1.11.1;
 			};
 		};
 		86D31808271655B300B43379 /* XCRemoteSwiftPackageReference "splunk-otel-ios" */ = {

--- a/SplunkRumCrashReporting/SplunkRumCrashReporting/CrashReporting.swift
+++ b/SplunkRumCrashReporting/SplunkRumCrashReporting/CrashReporting.swift
@@ -19,7 +19,8 @@ import Foundation
 import CrashReporter
 import SplunkOtel
 
-let CrashReportingVersionString = "0.5.1"
+// Make sure the version numbers on the podspec and CrashReporting.swift match
+let CrashReportingVersionString = "0.6.0"
 
 var TheCrashReporter: PLCrashReporter?
 private var customDataDictionary: [String: String] = [String: String]()

--- a/SplunkRumCrashReporting/SplunkRumCrashReporting/CrashReporting.swift
+++ b/SplunkRumCrashReporting/SplunkRumCrashReporting/CrashReporting.swift
@@ -18,9 +18,8 @@ limitations under the License.
 import Foundation
 import CrashReporter
 import SplunkOtel
-import OpenTelemetryApi
 
-let CrashReportingVersionString = "0.5.0"
+let CrashReportingVersionString = "0.5.1"
 
 var TheCrashReporter: PLCrashReporter?
 private var customDataDictionary: [String: String] = [String: String]()

--- a/fullbuild.sh
+++ b/fullbuild.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 swiftlint --strict
+
+# Make sure the version numbers on the podspec and CrashReporting.swift match
+echo "Checking that version numbers match"
+rumVer="$(grep SplunkRumVersionString SplunkRumCrashReporting/SplunkRumCrashReporting/CrashReporting.swift | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
+podVer="$(grep s.version SplunkOtel.podspec | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
+if [ $podVer != $rumVer ]; then
+    echo "Error: The version numbers in SplunkOtel.podspec and SplunkRum.swift do not match"
+    exit 1
+fi
+
 xcodebuild -project SplunkRumCrashReporting/SplunkRumCrashReporting.xcodeproj -scheme SplunkRumCrashReporting -configuration Debug build
 xcodebuild -project SplunkRumCrashReporting/SplunkRumCrashReporting.xcodeproj -scheme SplunkRumCrashReporting -configuration Debug test
 xcodebuild -project SplunkRumCrashReporting/SplunkRumCrashReporting.xcodeproj -scheme SplunkRumCrashReporting -configuration Release build

--- a/fullbuild.sh
+++ b/fullbuild.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
-set -e
+set -ex
 swiftlint --strict
 
 # Make sure the version numbers on the podspec and CrashReporting.swift match
 echo "Checking that version numbers match"
-rumVer="$(grep SplunkRumVersionString SplunkRumCrashReporting/SplunkRumCrashReporting/CrashReporting.swift | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
-podVer="$(grep s.version SplunkOtel.podspec | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
+rumVer="$(grep CrashReportingVersionString SplunkRumCrashReporting/SplunkRumCrashReporting/CrashReporting.swift | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
+podVer="$(grep s.version SplunkOtelCrashReporting.podspec | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
 if [ $podVer != $rumVer ]; then
-    echo "Error: The version numbers in SplunkOtel.podspec and SplunkRum.swift do not match"
+    echo "Error: The version numbers in SplunkOtelCrashReporting.podspec and SplunkRum.swift do not match"
     exit 1
 fi
+
+# Check the podspec is valid
+pod lib lint SplunkOtelCrashReporting.podspec
 
 xcodebuild -project SplunkRumCrashReporting/SplunkRumCrashReporting.xcodeproj -scheme SplunkRumCrashReporting -configuration Debug build
 xcodebuild -project SplunkRumCrashReporting/SplunkRumCrashReporting.xcodeproj -scheme SplunkRumCrashReporting -configuration Debug test


### PR DESCRIPTION
Updates the project to work with the recent SplunkOtel release. This includes:
*  A podspec to support cocoapods.
* Bumping PLCrashReporter dependency to 1.11.1 for Cocoapods compliance
* Removing references to OpenTelemetryAPI as it's now contained within the SplunkOtel project.